### PR TITLE
PC-22: fix build process race condition

### DIFF
--- a/.github/workflows/daily-develop-build.yml
+++ b/.github/workflows/daily-develop-build.yml
@@ -6,6 +6,11 @@ on:
   # everyday at noon
   - cron: "0 12 * * *"
 
+# This locks out merge-to-develop so we don't pull in a state that is missing a commit, specifically the version commit.
+# It could be confusing if we try to debug this workflow and develop having a state that is invalid
+concurrency:
+    group: develop-lock
+
 jobs:
 
   # build our project

--- a/.github/workflows/merge-to-develop.yml
+++ b/.github/workflows/merge-to-develop.yml
@@ -6,6 +6,11 @@ on:
     types: [closed]
     branches: [develop]
 
+# Only one instance of this workflow can run at a time. Also locks out daily-develop-build (this is so our history is kept tidy)
+# if we want to just lock this workflow use ${{ github.workflow }} instead of develop-lock
+concurrency:
+    group: develop-lock
+
 jobs:
   # build our project
   build:
@@ -14,7 +19,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    name: Run with after merge to develop
+    name: Run after merge to develop
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
@@ -36,7 +41,7 @@ jobs:
         run: pytest pavo_cristatus/tests
 
       # HACK ALERT: awk was being absolutely retarded... It returns the incorrect column for git log. I think it has to do with the string containing a "/"
-      # we find the merge commit as it will be first commit with a BOBA branch as a ref and pull the ref from that commit
+      # we find the merge commit as it will be first commit with a pavo_cristatus branch as a ref and pull the ref from that commit
       # we then replace the character "-" with " " and print out the 2nd column which will be the version increment in that branch name
       - name: echo output of complicated one-liner
         run: echo $(git log -2 --format=%D | awk '{print $1}' | tr / " " | awk '{print $2}' | tr - " " | awk '{print $2}')
@@ -46,13 +51,13 @@ jobs:
       - name: increment version
         run: git log -2 --format=%D | awk '{print $1}' | tr / " " | awk '{print $2}' | tr - " " | awk '{print $2}' | xargs ./build_scripts/increment_version_number.py ${version_increment}
 
-      # writing my own amend step and not using existing commit actions because those actions change the author. I want to preserve the commit as is (except for the version.txt)
+      # writing my own commit step and not using existing commit actions because those actions change the author. I want to preserve the commit as is (except for the version.txt)
       - name: amend commit
         run: |
             git config --global user.name $(git log -1 --format=%an)
             git config --global user.email $(git log -1 --format=%ae)
             git add version.txt
-            git commit --amend --no-edit
+            git commit -m "version increment for $(git log -1 --format=%b)"
             git push -f
 
       

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -15,7 +15,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    name: Run with after merge to master
+    name: Run after merge to master
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,7 +1,11 @@
-name: Pull Request Action
+name: Pull Request Build
 
 # Controls when the action will run (on pull request)
 on: [pull_request]
+
+# locks out post-version-increment
+concurrency:
+    group: develop-lock
 
 jobs:
 
@@ -17,6 +21,14 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+
+      # HACK ALERT: required to be able to switch between branches
+      - name: fetch branches
+        run: |
+            git fetch --no-tags --depth=1 origin develop
+            git checkout -b develop
+            git fetch --no-tags origin ${{ github.event.pull_request.head.sha }}
+            git checkout ${{ github.event.pull_request.head.sha }}
       
       - uses: actions/setup-python@v2
         with:
@@ -26,6 +38,14 @@ jobs:
         # if branch name is not of the form <change type>-<version increment type>-<project>-<ticket number> or master or develop, we fail the build
         # sorry don't know multi-line conditionals
         run: "! $( [[ $(git branch --show-current) =~ ^(bugfix|task|hotfix)-(major|minor|patch)-PC-[1-9][0-9]*$ ]] || [[ $(git branch --show-current) == develop ]] || [[ $(git branch --show-current) == master ]] )"
+
+      # if branch version is not the same as develop, branch needs to be updated (rebased back onto develop)
+      - name: check version
+        run: |
+          git checkout develop
+          develop_version=$(cat ./version.txt)
+          git checkout ${{ github.event.pull_request.head.sha }}
+          python ./build_scripts/check_version.py ${develop_version}
 
       - name: install
         run: |

--- a/build_scripts/check_version.py
+++ b/build_scripts/check_version.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+
+import argparse
+
+parser = argparse.ArgumentParser(description='Take in develop version string')
+parser.add_argument('develop_version', type=str, help='develop version')
+
+args = parser.parse_args()
+
+if args.develop_version is None:
+    raise ValueError("develop version missing")
+
+develop_version = args.develop_version.strip()
+
+version_path = "version.txt"
+
+with open(version_path, "r") as f:
+    branch_version = f.readline().strip()
+
+if develop_version != branch_version:
+    raise ValueError("branch version differs from develop. branch version: {0}, develop version {1}".format(branch_version, develop_version))

--- a/build_scripts/generate_rc_build_number.py
+++ b/build_scripts/generate_rc_build_number.py
@@ -13,7 +13,7 @@ version_path = "version.txt"
 build_type = "rc"
 
 with open(version_path, "r") as f:
-    version = f.readline()
+    version = f.readline().strip()
 
 build_number = 0
 tag = "{0}-{1}.{2}".format(version, build_type, build_number)


### PR DESCRIPTION
Hopefully this is enough. One concern is that after merging into develop and adding a commit for version increment, merge conflicts might not arise to prevent from an incorrect version increment. When no merge conflicts arise the version increment seems to behave correctly.