### PR TITLE
Support classmethods/staticmethods

### DIFF
--- a/pavo_cristatus/project_loader/nested_symbol_collector.py
+++ b/pavo_cristatus/project_loader/nested_symbol_collector.py
@@ -31,9 +31,9 @@ def collect_nested_symbols_in_object_dict(normalized_symbol):
         if type(nested_symbol) == property:
             continue
 
-        # TODO: handle static methods
-        #if type(nested_symbol) in (staticmethod, classmethod):
-        #    continue
+        # if we do not access __func__, we risk inspecting the staticmethod/classmethod wrapper instead
+        if type(nested_symbol) in (staticmethod, classmethod):
+            nested_symbol = nested_symbol.__func__
 
         if nested_symbol is None:
             continue

--- a/pavo_cristatus/tests/doubles/module_fakes/annotated/module_fake_class_with_classes.py
+++ b/pavo_cristatus/tests/doubles/module_fakes/annotated/module_fake_class_with_classes.py
@@ -9,3 +9,11 @@ class ModuleFakeClassWithClasses(with_metaclass(ModuleFakeClass)):
         def symbol_of_interest(self, a : int, b : str) -> bool: pass
     class NonSymbolOfInterest:
         def non_symbol_of_interest(self, a, b): pass
+
+    class SymbolOfInterestClassMethod:
+        @classmethod
+        def class_method(cls, a: int, b : str) -> bool: pass
+    
+    class SymbolOfInterestStaticMethod:
+        @staticmethod
+        def static_method(a : int, b : str) -> bool: pass

--- a/pavo_cristatus/tests/interactions_tests/test_symbol_signature_replacer_interaction.py
+++ b/pavo_cristatus/tests/interactions_tests/test_symbol_signature_replacer_interaction.py
@@ -32,12 +32,14 @@ def safe_open_hook(*args, **kwargs):
 
 symbols_under_test = [ModuleFakeClassWithCallables.non_symbol_of_interest,
                       ModuleFakeClassWithClasses.NonSymbolOfInterest,
+                      ModuleFakeClassWithClasses.SymbolOfInterestClassMethod,
+                      ModuleFakeClassWithClasses.SymbolOfInterestStaticMethod,
                       ModuleFakeClassWithInheritedAnnotatedCallables.SymbolOfInterest,
                       ModuleFakeClassWithInheritedAnnotatedCallables.NonSymbolOfInterest,
                       ModuleFakeClassWithClassesWithNestedAnnotatedCallables.NonSymbolOfInterest,
-                      ModuleFakeClassWithClassesWithNestedAnnotatedCallables.SymbolOfInterest]
+                      ModuleFakeClassWithClassesWithNestedAnnotatedCallables.SymbolOfInterest,]
 
-# these are only supported by python 3.9 (all of the following symbols will cause syntax errors)
+# these are only supported by python 3.9 (all the following symbols will cause syntax errors)
 if sys.version_info >= (3, 9):
     from pavo_cristatus.tests.doubles.module_fakes.annotated.module_fake_class_with_nested_lambda_decorated_classes import \
         ModuleFakeClassWithNestedLambdaDecoratedClasses


### PR DESCRIPTION
We were running into an issue where we inspecting the wrapper classmethod/static method instead of the inner function. This was fixed through accessing __func__ on these objects while we collect symbols.